### PR TITLE
Changes to TYPE_OF_LOCATORS mapping & addition of custom Exceptions

### DIFF
--- a/seleniumpagefactory/Pagefactory.py
+++ b/seleniumpagefactory/Pagefactory.py
@@ -6,6 +6,14 @@ from selenium.webdriver import ActionChains
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support.ui import Select
 
+class PageFactoryException(Exception):
+    """Base class for exceptions in this module."""
+    pass
+class ElementNotFoundException(PageFactoryException):
+    """Raised when the element is not found in the page. (Using ` EC.presence_of_element_located` function from within __getattr__ method)."""
+class ElementNotVisibleException(PageFactoryException):
+    """Raised when the element is not visible in the page. (Using `EC.visibility_of_element_located` function from within __getattr__ method)."""
+
 
 class PageFactory(object):
     timeout = 10
@@ -46,7 +54,7 @@ class PageFactory(object):
                         EC.presence_of_element_located(locator)
                     )
                 except (StaleElementReferenceException, NoSuchElementException, TimeoutException) as e:
-                    raise Exception(
+                    raise ElementNotFoundException(
                         "An exception of type " + type(e).__name__ +
                         " occurred. With Element -: " + loc +
                         " - locator: (" + locator[0] + ", " + locator[1] + ")"
@@ -57,7 +65,7 @@ class PageFactory(object):
                         EC.visibility_of_element_located(locator)
                     )
                 except (StaleElementReferenceException, NoSuchElementException, TimeoutException) as e:
-                    raise Exception(
+                    raise ElementNotVisibleException(
                         "An exception of type " + type(e).__name__ +
                         " occurred. With Element -: " + loc +
                         " - locator: (" + locator[0] + ", " + locator[1] + ")"

--- a/seleniumpagefactory/Pagefactory.py
+++ b/seleniumpagefactory/Pagefactory.py
@@ -21,14 +21,14 @@ class PageFactory(object):
     mobile_test = False     #Added for Mobile support
 
     TYPE_OF_LOCATORS = {
-        'css selector': By.CSS_SELECTOR,
+        'css': By.CSS_SELECTOR,
         'id': By.ID,
         'name': By.NAME,
         'xpath': By.XPATH,
         'link_text': By.LINK_TEXT,
-        'partial link text': By.PARTIAL_LINK_TEXT,
-        'tag name': By.TAG_NAME,
-        'class name': By.CLASS_NAME
+        'partial_link_text': By.PARTIAL_LINK_TEXT,
+        'tag': By.TAG_NAME,
+        'class_name': By.CLASS_NAME
     }
 
     def __init__(self):

--- a/seleniumpagefactory/Pagefactory.py
+++ b/seleniumpagefactory/Pagefactory.py
@@ -13,14 +13,14 @@ class PageFactory(object):
     mobile_test = False     #Added for Mobile support
 
     TYPE_OF_LOCATORS = {
-        'css': By.CSS_SELECTOR,
+        'css selector': By.CSS_SELECTOR,
         'id': By.ID,
         'name': By.NAME,
         'xpath': By.XPATH,
         'link_text': By.LINK_TEXT,
-        'partial_link_text': By.PARTIAL_LINK_TEXT,
-        'tag': By.TAG_NAME,
-        'class_name': By.CLASS_NAME
+        'partial link text': By.PARTIAL_LINK_TEXT,
+        'tag name': By.TAG_NAME,
+        'class name': By.CLASS_NAME
     }
 
     def __init__(self):


### PR DESCRIPTION
As per the commit descriptions, I propose changes to the locator mapping dictionary: `TYPE_OF_LOCATORS` in order to align with the definitions in https://github.com/SeleniumHQ/selenium/blob/trunk/py/selenium/webdriver/common/by.py

I would expect this may be a breaking change - In fact, by leaving in prior dict keys it maybe needn't be.

Additionally, added custom exceptions to expand the usability of the on-the-fly WebElement attributes, allowing us to handle a custom exception rather than excepting *all* Exceptions arising during this execution.

Would very much appreciate comment/feedback if you agree or would like discuss.

Thanks